### PR TITLE
CALCITE-3486 In JDBC Adapter, Unparse ROW keyword if Dialect Allows

### DIFF
--- a/babel/pom.xml
+++ b/babel/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-drill-r4</version>
+    <version>1.21.0-drill-r5</version>
   </parent>
 
   <artifactId>calcite-babel</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-drill-r4</version>
+  <version>1.21.0-drill-r5</version>
   <name>Calcite Babel</name>
   <description>Calcite Babel</description>
 

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-drill-r4</version>
+    <version>1.21.0-drill-r5</version>
   </parent>
 
   <artifactId>calcite-cassandra</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-drill-r4</version>
+  <version>1.21.0-drill-r5</version>
   <name>Calcite Cassandra</name>
   <description>Cassandra adapter for Calcite</description>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-drill-r4</version>
+    <version>1.21.0-drill-r5</version>
   </parent>
 
   <artifactId>calcite-core</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-drill-r4</version>
+  <version>1.21.0-drill-r5</version>
   <name>Calcite Core</name>
   <description>Core Calcite APIs and engine.</description>
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -451,7 +451,29 @@ public class SqlDialect {
 
   public void unparseCall(SqlWriter writer, SqlCall call, int leftPrec,
       int rightPrec) {
-    call.getOperator().unparse(writer, call, leftPrec, rightPrec);
+    switch (call.getKind()) {
+    case ROW:
+      // Remove the ROW keyword if the dialect does not allow that.
+      if (!getConformance().allowExplicitRowValueConstructor()) {
+        // Fix the syntax when there is no parentheses after VALUES keyword.
+        if (!writer.isAlwaysUseParentheses()) {
+          writer.print(" ");
+        }
+        final SqlWriter.Frame frame = writer.isAlwaysUseParentheses()
+                ? writer.startList(SqlWriter.FrameTypeEnum.FUN_CALL)
+                : writer.startList(SqlWriter.FrameTypeEnum.FUN_CALL, "(", ")");
+        for (SqlNode operand : call.getOperandList()) {
+          writer.sep(",");
+          operand.unparse(writer, leftPrec, rightPrec);
+        }
+        writer.endList(frame);
+        break;
+      }
+      call.getOperator().unparse(writer, call, leftPrec, rightPrec);
+      break;
+    default:
+      call.getOperator().unparse(writer, call, leftPrec, rightPrec);
+    }
   }
 
   public void unparseDateTimeLiteral(SqlWriter writer,
@@ -1101,6 +1123,7 @@ public class SqlDialect {
    * {@link #databaseProduct}; sub-classes may override. */
   @Nonnull public SqlConformance getConformance() {
     switch (databaseProduct) {
+    case UNKNOWN:
     case CALCITE:
       return SqlConformanceEnum.DEFAULT;
     case MYSQL:

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -1145,6 +1145,37 @@ public class SqlParserTest {
     sql(whereRow2).sansCarets().ok(whereExpected);
   }
 
+  @Test public void testRowValueExpression() {
+    final String expected0 = "INSERT INTO \"EMPS\"\n"
+            + "VALUES (ROW(1, 'Fred')),\n"
+            + "(ROW(2, 'Eric'))";
+    String sql = "insert into emps values (1,'Fred'),(2, 'Eric')";
+    sql(sql)
+        .withDialect(SqlDialect.DatabaseProduct.CALCITE.getDialect())
+         .ok(expected0);
+
+    final String expected1 = "INSERT INTO `emps`\n"
+            + "VALUES (1, 'Fred'),\n"
+            + "(2, 'Eric')";
+    sql(sql)
+        .withDialect(SqlDialect.DatabaseProduct.MYSQL.getDialect())
+        .ok(expected1);
+
+    final String expected2 = "INSERT INTO \"EMPS\"\n"
+            + "VALUES (1, 'Fred'),\n"
+            + "(2, 'Eric')";
+    sql(sql)
+        .withDialect(SqlDialect.DatabaseProduct.ORACLE.getDialect())
+        .ok(expected2);
+
+    final String expected3 = "INSERT INTO [EMPS]\n"
+            + "VALUES (1, 'Fred'),\n"
+            + "(2, 'Eric')";
+    sql(sql)
+        .withDialect(SqlDialect.DatabaseProduct.MSSQL.getDialect())
+        .ok(expected3);
+  }
+
   /** Whether this is a sub-class that tests un-parsing as well as parsing. */
   protected boolean isUnparserTest() {
     return false;

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-drill-r4</version>
+    <version>1.21.0-drill-r5</version>
   </parent>
 
   <artifactId>calcite-druid</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-drill-r4</version>
+  <version>1.21.0-drill-r5</version>
   <name>Calcite Druid</name>
   <description>Druid adapter for Calcite</description>
 

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -21,12 +21,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-drill-r4</version>
+    <version>1.21.0-drill-r5</version>
   </parent>
 
   <artifactId>calcite-elasticsearch</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-drill-r4</version>
+  <version>1.21.0-drill-r5</version>
   <name>Calcite Elasticsearch</name>
   <description>Elasticsearch adapter for Calcite</description>
 

--- a/example/csv/pom.xml
+++ b/example/csv/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite-example</artifactId>
-    <version>1.21.0-drill-r4</version>
+    <version>1.21.0-drill-r5</version>
   </parent>
 
   <artifactId>calcite-example-csv</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-drill-r4</version>
+  <version>1.21.0-drill-r5</version>
   <name>Calcite Example CSV</name>
   <description>An example Calcite provider that reads CSV files</description>
 

--- a/example/function/pom.xml
+++ b/example/function/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite-example</artifactId>
-    <version>1.21.0-drill-r4</version>
+    <version>1.21.0-drill-r5</version>
   </parent>
 
   <artifactId>calcite-example-function</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-drill-r4</version>
+  <version>1.21.0-drill-r5</version>
   <name>Calcite Example Function</name>
   <description>Examples of user-defined Calcite functions</description>
 

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -20,13 +20,13 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-drill-r4</version>
+    <version>1.21.0-drill-r5</version>
   </parent>
 
   <!-- The basics. -->
   <artifactId>calcite-example</artifactId>
   <packaging>pom</packaging>
-  <version>1.21.0-drill-r4</version>
+  <version>1.21.0-drill-r5</version>
   <name>Calcite Examples</name>
   <description>Calcite examples</description>
 

--- a/file/pom.xml
+++ b/file/pom.xml
@@ -19,13 +19,13 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-drill-r4</version>
+    <version>1.21.0-drill-r5</version>
   </parent>
 
   <!-- The basics. -->
   <artifactId>calcite-file</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-drill-r4</version>
+  <version>1.21.0-drill-r5</version>
   <name>Calcite File</name>
   <description>Calcite provider that reads files and URIs</description>
 

--- a/geode/pom.xml
+++ b/geode/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-drill-r4</version>
+    <version>1.21.0-drill-r5</version>
   </parent>
 
   <artifactId>calcite-geode</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-drill-r4</version>
+  <version>1.21.0-drill-r5</version>
   <name>Calcite Geode</name>
   <description>Geode adapter for Calcite</description>
 

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-drill-r4</version>
+    <version>1.21.0-drill-r5</version>
   </parent>
 
   <!-- The basics. -->

--- a/linq4j/pom.xml
+++ b/linq4j/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-drill-r4</version>
+    <version>1.21.0-drill-r5</version>
   </parent>
 
   <artifactId>calcite-linq4j</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-drill-r4</version>
+  <version>1.21.0-drill-r5</version>
   <name>Calcite Linq4j</name>
   <description>Calcite APIs for LINQ (Language-Integrated Query) in Java</description>
 

--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-drill-r4</version>
+    <version>1.21.0-drill-r5</version>
   </parent>
 
   <artifactId>calcite-mongodb</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-drill-r4</version>
+  <version>1.21.0-drill-r5</version>
   <name>Calcite MongoDB</name>
   <description>MongoDB adapter for Calcite</description>
 

--- a/pig/pom.xml
+++ b/pig/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-drill-r4</version>
+    <version>1.21.0-drill-r5</version>
   </parent>
 
   <artifactId>calcite-pig</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-drill-r4</version>
+  <version>1.21.0-drill-r5</version>
   <name>Calcite Pig</name>
   <description>Pig adapter for Calcite</description>
 

--- a/piglet/pom.xml
+++ b/piglet/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-drill-r4</version>
+    <version>1.21.0-drill-r5</version>
   </parent>
 
   <artifactId>calcite-piglet</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-drill-r4</version>
+  <version>1.21.0-drill-r5</version>
   <name>Calcite Piglet</name>
   <description>Pig-like language built on top of Calcite algebra</description>
 

--- a/plus/pom.xml
+++ b/plus/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-drill-r4</version>
+    <version>1.21.0-drill-r5</version>
   </parent>
 
   <artifactId>calcite-plus</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-drill-r4</version>
+  <version>1.21.0-drill-r5</version>
   <name>Calcite Plus</name>
   <description>Miscellaneous extras for Calcite</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ limitations under the License.
   <groupId>org.apache.calcite</groupId>
   <artifactId>calcite</artifactId>
   <packaging>pom</packaging>
-  <version>1.21.0-drill-r4</version>
+  <version>1.21.0-drill-r5</version>
 
   <!-- More project information. -->
   <name>Calcite</name>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-drill-r4</version>
+    <version>1.21.0-drill-r5</version>
   </parent>
 
   <artifactId>calcite-server</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-drill-r4</version>
+  <version>1.21.0-drill-r5</version>
   <name>Calcite Server</name>
   <description>Calcite Server</description>
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-drill-r4</version>
+    <version>1.21.0-drill-r5</version>
   </parent>
 
   <artifactId>calcite-spark</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-drill-r4</version>
+  <version>1.21.0-drill-r5</version>
   <name>Calcite Spark</name>
 
   <properties>

--- a/splunk/pom.xml
+++ b/splunk/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-drill-r4</version>
+    <version>1.21.0-drill-r5</version>
   </parent>
 
   <artifactId>calcite-splunk</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-drill-r4</version>
+  <version>1.21.0-drill-r5</version>
   <name>Calcite Splunk</name>
   <description>Splunk adapter for Calcite; also a JDBC driver for Splunk</description>
 

--- a/ubenchmark/pom.xml
+++ b/ubenchmark/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-drill-r4</version>
+    <version>1.21.0-drill-r5</version>
   </parent>
 
   <properties>


### PR DESCRIPTION
For DRILL-8005 (https://github.com/apache/drill/pull/2327), Calcite was inserting the `ROW` keyword for dialects that do not support it.  This was fixed in CALCITE-3486 (https://github.com/apache/calcite/pull/1568).  This PR includes the fix and bumps the version to `v5`.